### PR TITLE
Change temp folder location from external storage to internal cache

### DIFF
--- a/app/src/main/java/linc/com/amplituda/Amplituda.java
+++ b/app/src/main/java/linc/com/amplituda/Amplituda.java
@@ -21,7 +21,7 @@ public final class Amplituda {
     private String amplitudes;
 
     public Amplituda(Context context) {
-        this.temporaryAmplitudaDataFile = context.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS)
+        this.temporaryAmplitudaDataFile = context.getCacheDir()
                 .getPath() + File.separator + AMPLITUDA_TMP_VALUES;
     }
 


### PR DESCRIPTION
In new android versions, WRITE_EXTERNAL_STORAGE is not available and Amplituda won't work without this permission.

Issue is with temporaryAmplitudaDataFile. We could use:

context.getCacheDir()

instead of

context.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS)

This is a better solution as temp files by design should go to the internal cache folder.
This also doesn't require any READ or WRITE permissions.

Also, you can make a setter for temporaryAmplitudaDataFile so developers can choose between temp file directories.