### PR TITLE
Update proguard-rules.pro for release build

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,5 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keep class linc.com.amplituda.** { *; }


### PR DESCRIPTION
Hello, I update the proguard-rules so that library users could have a place for reference when they receive crashes on their release build.